### PR TITLE
Check that Prometheus tarball has not been modified

### DIFF
--- a/packer/prometheus.json
+++ b/packer/prometheus.json
@@ -4,7 +4,8 @@
     "triton_key_id": "{{ env `SDC_KEY_ID` }}",
     "triton_url": "{{ env `SDC_URL` }}",
     "timestamp": "{{ isotime \"2006-01-02T030405Z\" }}",
-    "version": "2.2.1",
+    "version": "2.3.2",
+    "checksum": "351931fe9bb252849b7d37183099047fbe6d7b79dcba013fb6ae19cc1bbd8552",
     "cmon_dns_suffix": "",
     "cmon_endpoint": "",
     "cmon_cert_file_path": "",
@@ -25,6 +26,7 @@
       "source_machine_package": "g4-general-4G",
       "source_machine_metadata": {
         "prometheus_version": "{{ user `version` }}",
+        "prometheus_checksum": "{{ user `checksum` }}",
         "cmon_dns_suffix": "{{ user `cmon_dns_suffix` }}",
         "cmon_endpoint": "{{ user `cmon_endpoint` }}"
       },


### PR DESCRIPTION
In my packer build (based off this one) I am manually checking Prometheus against a hardcoded sha256sum. This is effectively a trust-on-first-use model that lets me know if the published version of Prometheus has changed since the first time I downloaded it.

Hopefully this is useful to you or someone else finding this PR.